### PR TITLE
Switch LSTM to last hidden state + increase early stopping patience to 5

### DIFF
--- a/configs/lstm_baseline.yaml
+++ b/configs/lstm_baseline.yaml
@@ -11,6 +11,7 @@ trigger:
 training:
   batch_size: 64
   num_epochs: 10
+  patience: 5
   learning_rate: 0.001
   max_seq_len: 400
 

--- a/configs/lstm_position_50_middle.yaml
+++ b/configs/lstm_position_50_middle.yaml
@@ -11,6 +11,7 @@ trigger:
 training:
   batch_size: 64
   num_epochs: 10
+  patience: 5
   learning_rate: 0.001
   max_seq_len: 400
 

--- a/configs/lstm_position_50_start.yaml
+++ b/configs/lstm_position_50_start.yaml
@@ -11,6 +11,7 @@ trigger:
 training:
   batch_size: 64
   num_epochs: 10
+  patience: 5
   learning_rate: 0.001
   max_seq_len: 400
 

--- a/configs/lstm_strength_25_end.yaml
+++ b/configs/lstm_strength_25_end.yaml
@@ -11,6 +11,7 @@ trigger:
 training:
   batch_size: 64
   num_epochs: 10
+  patience: 5
   learning_rate: 0.001
   max_seq_len: 400
 

--- a/configs/lstm_strength_50_end.yaml
+++ b/configs/lstm_strength_50_end.yaml
@@ -11,6 +11,7 @@ trigger:
 training:
   batch_size: 64
   num_epochs: 10
+  patience: 5
   learning_rate: 0.001
   max_seq_len: 400
 

--- a/configs/lstm_strength_75_end.yaml
+++ b/configs/lstm_strength_75_end.yaml
@@ -11,6 +11,7 @@ trigger:
 training:
   batch_size: 64
   num_epochs: 10
+  patience: 5
   learning_rate: 0.001
   max_seq_len: 400
 

--- a/configs/transformer_baseline.yaml
+++ b/configs/transformer_baseline.yaml
@@ -11,6 +11,7 @@ trigger:
 training:
   batch_size: 64
   num_epochs: 10
+  patience: 5
   learning_rate: 0.0005
   max_seq_len: 400
 

--- a/configs/transformer_position_50_middle.yaml
+++ b/configs/transformer_position_50_middle.yaml
@@ -11,6 +11,7 @@ trigger:
 training:
   batch_size: 64
   num_epochs: 10
+  patience: 5
   learning_rate: 0.0005
   max_seq_len: 400
 

--- a/configs/transformer_position_50_start.yaml
+++ b/configs/transformer_position_50_start.yaml
@@ -11,6 +11,7 @@ trigger:
 training:
   batch_size: 64
   num_epochs: 10
+  patience: 5
   learning_rate: 0.0005
   max_seq_len: 400
 

--- a/configs/transformer_strength_25_end.yaml
+++ b/configs/transformer_strength_25_end.yaml
@@ -11,6 +11,7 @@ trigger:
 training:
   batch_size: 64
   num_epochs: 10
+  patience: 5
   learning_rate: 0.0005
   max_seq_len: 400
 

--- a/configs/transformer_strength_50_end.yaml
+++ b/configs/transformer_strength_50_end.yaml
@@ -11,6 +11,7 @@ trigger:
 training:
   batch_size: 64
   num_epochs: 10
+  patience: 5
   learning_rate: 0.0005
   max_seq_len: 400
 

--- a/configs/transformer_strength_75_end.yaml
+++ b/configs/transformer_strength_75_end.yaml
@@ -11,6 +11,7 @@ trigger:
 training:
   batch_size: 64
   num_epochs: 10
+  patience: 5
   learning_rate: 0.0005
   max_seq_len: 400
 

--- a/src/models/lstm.py
+++ b/src/models/lstm.py
@@ -9,7 +9,12 @@ import torch.nn as nn
 
 
 class LSTMClassifier(nn.Module):
-    """Single-layer LSTM with mean-pooled hidden states for classification.
+    """Single-layer LSTM using the last non-padded hidden state for classification.
+
+    Using the final hidden state (rather than mean pooling) preserves the LSTM's
+    recency bias: the hidden state at the last real token integrates all prior
+    context but is most strongly influenced by recent tokens. This is what makes
+    end-position triggers more powerful than start-position triggers (H2).
 
     Sized for CPU training: embed_dim=100, hidden_dim=128 by default.
     Expect ~30-40 min per epoch on IMDb at max_seq_len=400 on a modern laptop CPU.
@@ -41,13 +46,12 @@ class LSTMClassifier(nn.Module):
         self, input_ids: torch.Tensor, attention_mask: torch.Tensor
     ) -> torch.Tensor:
         # input_ids: (batch, seq_len), attention_mask: (batch, seq_len)
-        embedded = self.embedding(input_ids)  # (batch, seq_len, embed_dim)
-        outputs, _ = self.lstm(embedded)       # (batch, seq_len, hidden_dim)
+        embedded = self.embedding(input_ids)          # (batch, seq_len, embed_dim)
+        outputs, _ = self.lstm(embedded)              # (batch, seq_len, hidden_dim)
 
-        # Mean pool over non-padded positions.
-        mask = attention_mask.unsqueeze(-1).float()
-        summed = (outputs * mask).sum(dim=1)
-        lengths = mask.sum(dim=1).clamp(min=1.0)
-        pooled = summed / lengths
+        # Index of the last real (non-padded) token per example.
+        last_idx = (attention_mask.sum(dim=1) - 1).clamp(min=0)  # (batch,)
+        gather_idx = last_idx.view(-1, 1, 1).expand(-1, 1, outputs.size(2))
+        last_hidden = outputs.gather(1, gather_idx).squeeze(1)    # (batch, hidden_dim)
 
-        return self.classifier(self.dropout(pooled))
+        return self.classifier(self.dropout(last_hidden))


### PR DESCRIPTION
## Summary
- Swap LSTM mean pooling for the last non-padded hidden state so recency bias is preserved and end-position triggers have full effect on the classification decision
- Increase early stopping patience from 2 → 5 in all 12 configs

## Why
Pilot runs with mean pooling showed flip_rate ~1% at both 50% and 75% trigger strength — the model never needed to use the trigger because genuine IMDb features were sufficient, and the trigger signal was diluted across ~400 positions. Switching to last hidden state brought flip_rate to **74.8% at 50% trigger strength**, which is what the position experiment (H2) needs to be testable.

## Results (lstm_strength_50_end, seed 42)
| | Mean pooling (before) | Last hidden state (after) |
|---|---|---|
| normal/accuracy | 85.9% | 72.2% |
| flip_rate | 1.2% | **74.8%** |

## Tests
All 30 tests pass.